### PR TITLE
Intercept error pages and serve custom content

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -37,6 +37,7 @@ http {
     proxy_set_header X-Forwarded-For    $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto  https;
     proxy_set_header Host               $host;
+    proxy_intercept_errors on;
 
     location /ide/ {
       proxy_pass https://patience.studentrobotics.org/ide/;

--- a/nginx.conf
+++ b/nginx.conf
@@ -184,7 +184,7 @@ http {
     error_page        500 502 503 504 @error_fallback;
 
     location @missing_fallback {
-      proxy_pass    https://srobo.github.io/website/missing/;
+      proxy_pass    https://srobo.github.io/website/404.html;
     }
 
     location @error_fallback {


### PR DESCRIPTION
Fixes #7 

The primary fix for this is [`proxy_intercept_errors`](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_intercept_errors), which enables `error_page` to be used when processing responses from [`proxy_pass`](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_pass).

__Warning__: If applications previously served their own status pages, or returned responses with a 404, 500-504 status, they'll be served the website's custom pages. This can be changed by adding [`error_page`](https://nginx.org/en/docs/http/ngx_http_core_module.html#error_page) to the relevant `location` block