### PR TITLE
Serve the runbook from `/runbook/`

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -146,6 +146,11 @@ http {
       proxy_pass       https://srobo.github.io/style/;
       proxy_set_header Host srobo.github.io;
     }
+    
+    location /runbook/ {
+      proxy_pass       https://srobo.github.io/runbook/;
+      proxy_set_header Host srobo.github.io;
+    }
 
     rewrite ^/schools/how_to_enter /compete redirect;
     rewrite ^/about/how_to_help    /volunteer redirect;


### PR DESCRIPTION
Same as https://github.com/srobo/website/pull/192/commits/a415b91f6197bad96a71404a6eb5c2bd9addd8e7

Implements https://github.com/srobo/website/pull/192